### PR TITLE
fix(gui): get user name from secure cookie

### DIFF
--- a/bondia/auth.py
+++ b/bondia/auth.py
@@ -2,7 +2,6 @@ from chimedb.core import connect as connect_chimedb
 from chimedb.core.mediawiki import MediaWikiUser
 
 import os
-import panel as pn
 import tornado
 
 
@@ -48,8 +47,6 @@ class CustomLoginHandler(tornado.web.RequestHandler):
             error_msg = "?error=" + tornado.escape.url_escape(str(err))
             self.redirect(os.getenv("BONDIA_ROOT_URL", "") + "/login" + error_msg)
         else:
-            # make the username accessible to the panel application
-            pn.state.cache["username"] = username
             self.set_current_user(username)
             self.redirect(os.getenv("BONDIA_NEXT_URL", "/"))
 

--- a/bondia/server.py
+++ b/bondia/server.py
@@ -41,10 +41,10 @@ class BondiaServer(Reader):
         if not self.data.index:
             raise ConfigError("No data available.")
 
-    def gui_instance(self):
+    def gui_instance(self, cookie_secret):
         # logger.debug(f"Starting user session {pn.state.curdoc.session_context.id}.")
         instance = BondiaGui(
-            self._template, self._width_drawer_widgets, self.data
+            self._template, self._width_drawer_widgets, self.data, cookie_secret
         ).render()
         return instance
 

--- a/scripts/bondia-server
+++ b/scripts/bondia-server
@@ -68,16 +68,20 @@ def start(configfile, show, port, num_procs, websocket_origin, login):
     kwargs = {}
     if login:
         kwargs["xsrf_cookies"] = True
-        kwargs["cookie_secret"] = secrets.token_hex()
+        cookie_secret = secrets.token_hex()
+        kwargs["cookie_secret"] = cookie_secret
 
         # We have to redirect to the login handler manually, because tornado doesn't know about
         # the root URL.
         kwargs["extra_patterns"] = [(r"/login", auth.CustomLoginHandler)]
         kwargs["auth_provider"] = AuthModule(auth.__file__)
+    else:
+        cookie_secret = None
 
-    # Create an instance of the GUI for each user session.
+    # Create an instance of the GUI for each user session. Pass cookie secret to application, so it
+    # can decode the user name cookie.
     def instance():
-        return server.gui_instance()
+        return server.gui_instance(cookie_secret)
 
     panel.serve(
         instance,


### PR DESCRIPTION
Instead of saving the user name in panel.state, where it is overwritten
by other sessions, always get it from the secure cookie.

Fixes #37