### PR TITLE
fix(template): Menu button wasn't displayed at all

### DIFF
--- a/bondia/templates/mwc.html
+++ b/bondia/templates/mwc.html
@@ -62,7 +62,7 @@ mwc-drawer {
     </div>
     <div class="appContent" slot="appContent">
         <mwc-top-app-bar-fixed class="appBar">
-            <mwc-icon-button icon="menu" slot="navigationIcon" class="appDrawerToggleButton"></mwc-icon-button>
+            <mwc-button raised="" icon="menu" label="Menu" slot="navigationIcon" class="appDrawerToggleButton" align="left"></mwc-button>
             <div slot="title" style="font-size:20px;">{{ subtitle }}</div>
             <mwc-icon-button icon="perm_identity" slot="actionItems" label="Login"></mwc-icon-button>
         </mwc-top-app-bar-fixed>


### PR DESCRIPTION
For some reason mwc-icon-button stopped working, so it's changed to
mwc-button with an icon on the side.