### PR TITLE
Async refresh plots and avoid repeat callbacks

### DIFF
--- a/bondia/plot/delayspectrum.py
+++ b/bondia/plot/delayspectrum.py
@@ -30,7 +30,7 @@ class DelaySpectrumBase(HeatMapPlot):
 
     # Hide lsd, revision selectors by setting precedence < 0
     lsd = param.Selector(precedence=-1)
-    revision = param.Selector(precedence=-1)
+    revision = ""  # param.Selector(precedence=-1)
 
     def __init__(self, data, config, **params):
         self.data = data
@@ -46,7 +46,7 @@ class DelaySpectrumBase(HeatMapPlot):
         self._fname = ""
 
     @param.depends(
-        "revision",
+        # "revision",
         "lsd",
         "transpose",
         "logarithmic_colorscale",

--- a/bondia/plot/sensitivity.py
+++ b/bondia/plot/sensitivity.py
@@ -39,7 +39,7 @@ class SensitivityPlot(RaHeatMapPlot, Reader):
     # parameters
     # Hide lsd, revision selectors by setting precedence < 0
     lsd = param.Selector(precedence=-1)
-    revision = param.Selector(precedence=-1)
+    revision = ""  # param.Selector(precedence=-1)
 
     polarization = param.ObjectSelector()
     mark_day_time = param.Boolean(default=True)
@@ -78,7 +78,8 @@ class SensitivityPlot(RaHeatMapPlot, Reader):
                     self.param.trigger("colormap_range")
                 self.colormap_range = self.zlim_estimate
 
-    @param.depends("lsd", "revision", watch=True)
+    # @param.depends("lsd", "revision", watch=True)
+    @param.depends("lsd", watch=True)
     def update_pol(self):
         if self.lsd is None:
             return
@@ -91,12 +92,15 @@ class SensitivityPlot(RaHeatMapPlot, Reader):
         if "XX" in objects and "YY" in objects:
             objects.append(self.mean_pol_text)
             value = self.mean_pol_text
-        self.param["polarization"].objects = objects
-        self.polarization = value
-        self.param.trigger("polarization")
+
+        if value != self.polarization:
+            self.param["polarization"].objects = objects
+            self.polarization = value
+        else:
+            self.param.trigger("polarization")
 
     @param.depends(
-        "lsd",
+        # "lsd",
         "transpose",
         "logarithmic_colorscale",
         "serverside_rendering",


### PR DESCRIPTION
This PR does 2 things:
1. When switching to a new day, the previous plots are hidden and loaded asynchronously, allowing the rest of the UI to update before the plots have loaded (and if they fail). This also means that any plots that fail to load remain hidden, with the caveat being that if someone manually re-displays the plot via the hide/show buttons, it will still display the old data. 
2. Some methods were getting called multiple times when loading a new day, because the callbacks were being triggered by multiple parameter changes. This catches most of those.

This PR breaks the functionality of the loading icon when loading new plots, because that doesn't work properly with the async loading for now.